### PR TITLE
Change to Footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Lights by the Lake 2024
+title: National Parks Board
 url: https://lightsbythelake.nparks.gov.sg
 favicon: /images/Partners & Logos/JLG_Secondary_Logo.png
 colors:

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: homepage
-title: Lights by the Lake 2024
+title: National Parks Board
 description: Be enchanted this Mid-Autumn Festival at Lights by the Lake 2024!
 image: /images/Key Visuals/LBTL_JLG_KV_800x450_v2.png
 permalink: /


### PR DESCRIPTION
Site title adjusted to "National Parks Board" for footer to reflect (c) 2025 National Parks Board. Last Updated on (date)